### PR TITLE
use atomic loader to load atomic values

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/divisionone/go-micro/broker"
 	"github.com/divisionone/go-micro/codec"
 	"github.com/divisionone/go-micro/errors"
 	"github.com/divisionone/go-micro/metadata"
 	"github.com/divisionone/go-micro/selector"
 	"github.com/divisionone/go-micro/transport"
-	"sync/atomic"
 )
 
 type rpcClient struct {
@@ -113,7 +114,7 @@ func (r *rpcClient) call(ctx context.Context, address string, req Request, resp 
 		r.pool.release(address, c, grr)
 	}()
 
-	seq := r.seq
+	seq := atomic.LeadUint64(&r.seq)
 	atomic.AddUint64(&r.seq, 1)
 
 	stream := &rpcStream{

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -114,7 +114,7 @@ func (r *rpcClient) call(ctx context.Context, address string, req Request, resp 
 		r.pool.release(address, c, grr)
 	}()
 
-	seq := atomic.LeadUint64(&r.seq)
+	seq := atomic.LoadUint64(&r.seq)
 	atomic.AddUint64(&r.seq, 1)
 
 	stream := &rpcStream{


### PR DESCRIPTION
Race detector goes mental when usvcs fire up multiple rpcs on startup.

This change makes the race detector less unhappy with these services.

Looks like without this, its possible for several concurrent call() functions to end up creating > 1 rpcStream with identical 'seq' values. 

Dont know how critical it is to have unique seq values, but given the effort to use atomic synch to increment the seq, you would think that it might be important.

Anyway - makes the race detector stop complaining for this case.