### PR TITLE
Bring consul options in partial alignment with upstream

### DIFF
--- a/registry/consul/options.go
+++ b/registry/consul/options.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	consul "github.com/hashicorp/consul/api"
 	"github.com/divisionone/go-micro/registry"
+	consul "github.com/hashicorp/consul/api"
 )
 
 func Config(c *consul.Config) registry.Option {
@@ -14,6 +14,40 @@ func Config(c *consul.Config) registry.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, "consul_config", c)
+	}
+}
+
+// AllowStale sets whether any Consul server (non-leader) can service
+// a read. This allows for lower latency and higher throughput
+// at the cost of potentially stale data.
+// Works similar to Consul DNS Config option [1].
+// Defaults to true.
+//
+// [1] https://www.consul.io/docs/agent/options.html#allow_stale
+//
+func AllowStale(v bool) registry.Option {
+	return func(o *registry.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_allow_stale", v)
+	}
+}
+
+// QueryOptions specifies the QueryOptions to be used when calling
+// Consul. See `Consul API` for more information [1].
+//
+// [1] https://godoc.org/github.com/hashicorp/consul/api#QueryOptions
+//
+func QueryOptions(q *consul.QueryOptions) registry.Option {
+	return func(o *registry.Options) {
+		if q == nil {
+			return
+		}
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, "consul_query_options", q)
 	}
 }
 


### PR DESCRIPTION
See https://github.com/micro/go-micro/pull/335