### PR TITLE
Log removed as it's a section that was marked as TODO by upstream.

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -108,7 +108,6 @@ func (s *rpcServer) accept(sock transport.Socket) {
 
 		// TODO: needs better error handling
 		if err := s.rpc.serveRequest(ctx, codec, ct); err != nil {
-			log.Logf("Unexpected error serving request, closing socket: %v", err)
 			return
 		}
 	}


### PR DESCRIPTION
API v2 services do have custom types for fields in the request messages.

go-micro doesn't get to the RPC when it cannot decode back to the type, e.g. UUIDs ("undefined" -> uuid.UUID), which logs this error in the service:

```
{"level":"info","msg":"Unexpected error serving request, closing socket: invalid UUID length: 9","package":"micro","time":"2020-10-07T23:24:56Z"}
```

The API does return a response back to the requester of RPC:

```
{"level":"info","msg":"Unexpected error serving request, closing socket: invalid UUID length: 9","package":"micro","time":"2020-09-30T01:29:12Z"}
```

