### PR TITLE
fix(locking): granular locking to aid in stream closure

### DIFF
--- a/client/rpc_stream.go
+++ b/client/rpc_stream.go
@@ -68,7 +68,10 @@ func (r *rpcStream) Recv(msg interface{}) error {
 	}
 
 	var resp response
-	if err := r.codec.ReadResponseHeader(&resp); err != nil {
+	r.Unlock()
+	err := r.codec.ReadResponseHeader(&resp)
+	r.Lock()
+	if err != nil {
 		if err == io.EOF && !r.isClosed() {
 			r.err = io.ErrUnexpectedEOF
 			return io.ErrUnexpectedEOF
@@ -87,11 +90,18 @@ func (r *rpcStream) Recv(msg interface{}) error {
 		} else {
 			r.err = io.EOF
 		}
-		if err := r.codec.ReadResponseBody(nil); err != nil {
+
+		r.Unlock()
+		err = r.codec.ReadResponseBody(nil)
+		r.Lock()
+		if err != nil {
 			r.err = err
 		}
 	default:
-		if err := r.codec.ReadResponseBody(msg); err != nil {
+		r.Unlock()
+		err = r.codec.ReadResponseBody(msg)
+		r.Lock()
+		if err != nil {
 			r.err = err
 		}
 	}
@@ -106,11 +116,15 @@ func (r *rpcStream) Error() error {
 }
 
 func (r *rpcStream) Close() error {
+	r.RLock()
+
 	select {
 	case <-r.closed:
+		r.RUnlock()
 		return nil
 	default:
 		close(r.closed)
+		r.RUnlock()
 		return r.codec.Close()
 	}
 }

--- a/server/rpc_stream.go
+++ b/server/rpc_stream.go
@@ -37,20 +37,28 @@ func (r *rpcStream) Send(msg interface{}) error {
 }
 
 func (r *rpcStream) Recv(msg interface{}) error {
+	req := request{}
+
+	err := r.codec.ReadRequestHeader(&req, false)
+
 	r.Lock()
 	defer r.Unlock()
 
-	req := request{}
-
-	if err := r.codec.ReadRequestHeader(&req, false); err != nil {
-		// discard body
+	if err != nil {
+		r.Unlock()
 		r.codec.ReadRequestBody(nil)
+		r.Lock()
 		return err
 	}
 
 	// we need to stay up to date with sequence numbers
 	r.seq = req.Seq
-	return r.codec.ReadRequestBody(msg)
+
+	r.Unlock()
+	err = r.codec.ReadRequestBody(msg)
+	r.Lock()
+
+	return err
 }
 
 func (r *rpcStream) Error() error {


### PR DESCRIPTION
### Note:

Patch ported from upstream here: https://github.com/asim/go-micro/pull/884/files

### Desc:

With the use of streams and `Send()` and `Recv()` functions using the same locks, it's not possible to send messages while waiting to receive them.

This patch from upstream uses the locks in a more granular fashion allowing simultaneous send/receive.