### PR TITLE
feat: pass RPC client call/stream context through to dialer

### DIFF
--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -78,7 +78,7 @@ func (r *rpcClient) call(ctx context.Context, address string, req Request, resp 
 	}
 
 	var grr error
-	c, err := r.pool.getConn(address, r.opts.Transport, transport.WithTimeout(opts.DialTimeout))
+	c, err := r.pool.getConn(address, r.opts.Transport, transport.WithTimeout(opts.DialTimeout), transport.WithContext(ctx))
 	if err != nil {
 		return errors.InternalServerError("go.micro.client", "connection error: %v", err)
 	}
@@ -158,7 +158,7 @@ func (r *rpcClient) stream(ctx context.Context, address string, req Request, opt
 		return nil, errors.InternalServerError("go.micro.client", err.Error())
 	}
 
-	c, err := r.opts.Transport.Dial(address, transport.WithStream(), transport.WithTimeout(opts.DialTimeout))
+	c, err := r.opts.Transport.Dial(address, transport.WithStream(), transport.WithTimeout(opts.DialTimeout), transport.WithContext(ctx))
 	if err != nil {
 		return nil, errors.InternalServerError("go.micro.client", "connection error: %v", err)
 	}

--- a/transport/options.go
+++ b/transport/options.go
@@ -91,3 +91,10 @@ func WithTimeout(d time.Duration) DialOption {
 		o.Timeout = d
 	}
 }
+
+// WithContext is an option to set the dialer context.
+func WithContext(ctx context.Context) DialOption {
+	return func(o *DialOptions) {
+		o.Context = ctx
+	}
+}


### PR DESCRIPTION
feat: pass RPC client call/stream context through to dialer, if dialing takes place