### PR TITLE
Adds server/Options.IdFunc config to generate a node identifier from RPC server listener details

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"context"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/divisionone/go-micro/broker"
 	"github.com/divisionone/go-micro/codec"
@@ -22,6 +22,7 @@ type Options struct {
 	Address      string
 	Advertise    string
 	Id           string
+	IdFunc       func(addr string, port int) string
 	Version      string
 	HdlrWrappers []HandlerWrapper
 	SubWrappers  []SubscriberWrapper

--- a/server/options.go
+++ b/server/options.go
@@ -22,7 +22,7 @@ type Options struct {
 	Address   string
 	Advertise string
 	Id        string
-	// IdFunc is an Id generator function called prior to registration of the service, replacing the Id option valuer.
+	// IdFunc is an Id generator function called prior to registration of the service, replacing the Id option value.
 	IdFunc       func(addr string, port int) string
 	Version      string
 	HdlrWrappers []HandlerWrapper

--- a/server/options.go
+++ b/server/options.go
@@ -13,15 +13,16 @@ import (
 )
 
 type Options struct {
-	Codecs       map[string]codec.NewCodec
-	Broker       broker.Broker
-	Registry     registry.Registry
-	Transport    transport.Transport
-	Metadata     map[string]string
-	Name         string
-	Address      string
-	Advertise    string
-	Id           string
+	Codecs    map[string]codec.NewCodec
+	Broker    broker.Broker
+	Registry  registry.Registry
+	Transport transport.Transport
+	Metadata  map[string]string
+	Name      string
+	Address   string
+	Advertise string
+	Id        string
+	// IdFunc is an Id generator function called prior to registration of the service, replacing the Id option valuer.
 	IdFunc       func(addr string, port int) string
 	Version      string
 	HdlrWrappers []HandlerWrapper

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -233,9 +233,14 @@ func (s *rpcServer) Register() error {
 		return err
 	}
 
+	nodeID := config.Name + "-" + config.Id
+	if config.IdFunc != nil {
+		nodeID = config.IdFunc(addr, port)
+	}
+
 	// register service
 	node := &registry.Node{
-		Id:       config.Name + "-" + config.Id,
+		Id:       nodeID,
 		Address:  addr,
 		Port:     port,
 		Metadata: config.Metadata,
@@ -309,7 +314,7 @@ func (s *rpcServer) Register() error {
 
 	s.registered = true
 
-	for sb, _ := range s.subscribers {
+	for sb := range s.subscribers {
 		handler := s.createSubHandler(sb, s.opts)
 		var opts []broker.SubscribeOption
 		if queue := sb.Options().Queue; len(queue) > 0 {
@@ -352,8 +357,13 @@ func (s *rpcServer) Deregister() error {
 		return err
 	}
 
+	nodeID := config.Name + "-" + config.Id
+	if config.IdFunc != nil {
+		nodeID = config.IdFunc(addr, port)
+	}
+
 	node := &registry.Node{
-		Id:      config.Name + "-" + config.Id,
+		Id:      nodeID,
 		Address: addr,
 		Port:    port,
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -233,14 +233,14 @@ func (s *rpcServer) Register() error {
 		return err
 	}
 
-	nodeID := config.Name + "-" + config.Id
+	id := config.Id
 	if config.IdFunc != nil {
-		nodeID = config.IdFunc(addr, port)
+		id = config.IdFunc(addr, port)
 	}
 
 	// register service
 	node := &registry.Node{
-		Id:       nodeID,
+		Id:       config.Name + "-" + id,
 		Address:  addr,
 		Port:     port,
 		Metadata: config.Metadata,
@@ -357,13 +357,13 @@ func (s *rpcServer) Deregister() error {
 		return err
 	}
 
-	nodeID := config.Name + "-" + config.Id
+	id := config.Id
 	if config.IdFunc != nil {
-		nodeID = config.IdFunc(addr, port)
+		id = config.IdFunc(addr, port)
 	}
 
 	node := &registry.Node{
-		Id:      nodeID,
+		Id:      config.Name + "-" + id,
 		Address: addr,
 		Port:    port,
 	}

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -233,14 +233,18 @@ func (s *rpcServer) Register() error {
 		return err
 	}
 
-	id := config.Id
 	if config.IdFunc != nil {
-		id = config.IdFunc(addr, port)
+		config.Id = config.IdFunc(addr, port)
+
+		// Propagate the identifier back to the service config under mutex.
+		s.Lock()
+		s.opts.Id = config.Id
+		s.Unlock()
 	}
 
 	// register service
 	node := &registry.Node{
-		Id:       config.Name + "-" + id,
+		Id:       config.Name + "-" + config.Id,
 		Address:  addr,
 		Port:     port,
 		Metadata: config.Metadata,
@@ -357,13 +361,8 @@ func (s *rpcServer) Deregister() error {
 		return err
 	}
 
-	id := config.Id
-	if config.IdFunc != nil {
-		id = config.IdFunc(addr, port)
-	}
-
 	node := &registry.Node{
-		Id:      config.Name + "-" + id,
+		Id:      config.Name + "-" + config.Id,
 		Address: addr,
 		Port:    port,
 	}


### PR DESCRIPTION
Servers can currently be provided an option (`Id`) during construction that will alter the identifier of the service node/instance in the registry.

We would like to be able to produce an identifier for the service which is deterministic and based on the RPC listener details of the service (ie. the address and port it bound to during startup). `go-micro` provided no such lifecycle hook between calls to `Start` and `Register`, so this new `IdFunc` option is being added to provide this custom behaviour.