### PR TITLE
feat: add transport.ListenOptions to server.Options

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -28,6 +28,8 @@ type Options struct {
 	HdlrWrappers []HandlerWrapper
 	SubWrappers  []SubscriberWrapper
 
+	ListenOptions []transport.ListenOption
+
 	RegisterTTL time.Duration
 
 	// Debug Handler which can be set by a user
@@ -191,5 +193,12 @@ func WrapHandler(w HandlerWrapper) Option {
 func WrapSubscriber(w SubscriberWrapper) Option {
 	return func(o *Options) {
 		o.SubWrappers = append(o.SubWrappers, w)
+	}
+}
+
+// ListenOptions appends the given listen options to the set passed into the server.
+func ListenOptions(opts ...transport.ListenOption) Option {
+	return func(o *Options) {
+		o.ListenOptions = append(o.ListenOptions, opts...)
 	}
 }

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -403,7 +403,7 @@ func (s *rpcServer) Start() error {
 	registerDebugHandler(s)
 	config := s.Options()
 
-	ts, err := config.Transport.Listen(config.Address)
+	ts, err := config.Transport.Listen(config.Address, config.ListenOptions...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
feat: add transport.ListenOptions to server.Options, passing them when Transport.Listen is called